### PR TITLE
Fixes #2

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -76,10 +76,10 @@ onBeforeUnmount(() => {
 .html,
 body,
 #app {
-  height: 100%;
+  height: 100vh;
 }
 .status {
-  height: 100%;
+  height: 100vh;
 }
 .message {
   text-align: center;


### PR DESCRIPTION
The height property value of *webkit-fill-available* seems to be only valid for the Chrome browsers.
Changing this to the more compatible 100vh, seems to fix the icon squash.